### PR TITLE
Use GitHubReleasesInfoProvider for Nextcloud

### DIFF
--- a/Nextcloud/NextcloudDesktopClient.download.recipe
+++ b/Nextcloud/NextcloudDesktopClient.download.recipe
@@ -2,16 +2,18 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>Comment</key>
-	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Nextcloud Desktop Client.</string>
 	<key>Identifier</key>
 	<string>com.github.peterkelm.download.nextcloud</string>
 	<key>Input</key>
 	<dict>
+		<key>GITHUB_REPO</key>
+		<string>nextcloud/desktop</string>
 		<key>NAME</key>
 		<string>Nextcloud</string>
+		<key>INCLUDE_PRERELEASES</key>
+		<string></string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -20,19 +22,21 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>https://github.com/nextcloud/desktop/releases</string>
-				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;https://download.nextcloud.com/desktop/releases/Mac/Installer/Nextcloud-[\d+\.]+.pkg)</string>
+				<key>github_repo</key>
+				<string>%GITHUB_REPO%</string>
+				<key>asset_regex</key>
+				<string>^Nextcloud-.*pkg$</string>
+				<key>include_prereleases</key>
+				<string>%INCLUDE_PRERELEASES%</string>
 			</dict>
 			<key>Processor</key>
-			<string>URLTextSearcher</string>
+			<string>GitHubReleasesInfoProvider</string>
 		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>url</key>
-				<string>%url%</string>
+				<key>filename</key>
+				<string>%NAME%.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
Right now this recipe cannot find Nextcloud 3.1.0, because it tries to find external links in the github release description that is missing for the most recent release. Instead I propose to use the GitHubReleasesInfoProvider directly. Here is a log for an example run:

```
Processing NextcloudDesktopClient.munki.recipe...
{'AUTOPKG_VERSION': '2.2',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GITHUB_REPO': 'nextcloud/desktop',
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'INCLUDE_PRERELEASES': '',
 'MUNKI_CATEGORY': 'Cloud',
 'MUNKI_REPO': '/mnt/munkipkgs/',
 'MUNKI_REPO_SUBDIR': 'apps/Nextcloud',
 'NAME': 'Nextcloud',
 'PARENT_RECIPES': ['/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes/Nextcloud/NextcloudDesktopClient.munki.recipe',
                    '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes/Nextcloud/NextcloudDesktopClient.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient',
 'RECIPE_DIR': '/Users/admin/Library/AutoPkg/RecipeOverrides',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/admin/Library/AutoPkg/RecipeOverrides/NextcloudDesktopClient.munki.recipe',
 'RECIPE_REPOS': {'/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.48kRAM-recipes': {'URL': 'https://github.com/autopkg/48kRAM-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.andrewvalentine-recipes': {'URL': 'https://github.com/autopkg/andrewvalentine-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.apettinen-recipes': {'URL': 'https://github.com/autopkg/apettinen-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.aysiu-recipes': {'URL': 'https://github.com/autopkg/aysiu-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.bochoven-recipes': {'URL': 'https://github.com/autopkg/bochoven-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes': {'URL': 'https://github.com/autopkg/dataJAR-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes': {'URL': 'https://github.com/autopkg/foigus-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.gerardkok-recipes': {'URL': 'https://github.com/autopkg/gerardkok-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes': {'URL': 'https://github.com/autopkg/grahamgilbert-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes': {'URL': 'https://github.com/autopkg/grahampugh-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.hansen-m-recipes': {'URL': 'https://github.com/autopkg/hansen-m-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes': {'URL': 'https://github.com/autopkg/hjuutilainen-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes': {'URL': 'https://github.com/autopkg/homebysix-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jaharmi-recipes': {'URL': 'https://github.com/autopkg/jaharmi-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes': {'URL': 'https://github.com/autopkg/jleggat-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes': {'URL': 'https://github.com/autopkg/joshua-d-miller-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jpiel-recipes': {'URL': 'https://github.com/autopkg/jpiel-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes': {'URL': 'https://github.com/autopkg/keeleysam-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes': {'URL': 'https://github.com/autopkg/killahquam-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes': {'URL': 'https://github.com/autopkg/mosen-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes': {'URL': 'https://github.com/autopkg/nmcspadden-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peshay-recipes': {'URL': 'https://github.com/autopkg/peshay-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes': {'URL': 'https://github.com/autopkg/peterkelm-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.robperc-recipes': {'URL': 'https://github.com/autopkg/robperc-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes': {'URL': 'https://github.com/autopkg/scriptingosx-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.timsutton-recipes': {'URL': 'https://github.com/autopkg/timsutton-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes': {'URL': 'https://github.com/autopkg/ygini-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.hjuutilainen.autopkg-virustotalanalyzer': {'URL': 'https://github.com/hjuutilainen/autopkg-virustotalanalyzer.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.mpib.autopkg-recipes': {'URL': 'https://github.com/mpib/autopkg-recipes'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.hansen-m-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.gerardkok-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.robperc-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.48kRAM-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.hjuutilainen.autopkg-virustotalanalyzer',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peshay-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.timsutton-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jaharmi-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.bochoven-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.aysiu-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.andrewvalentine-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.apettinen-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jpiel-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.mpib.autopkg-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes',
                        '',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes/Nextcloud'],
 'VIRUSTOTAL_ALWAYS_REPORT': False,
 'pkginfo': {'blocking_applications': ['nextcloud.app',
                                       'QtWebEngineProcess.app'],
             'catalogs': ['production'],
             'category': 'Cloud',
             'description': 'A safe home for all your data. Access, share and '
                            'protect your files, calendars, contacts, mail & '
                            'more from any device, on your terms.',
             'developer': 'Nextcloud GmbH',
             'display_name': 'Nextcloud (only for external data)',
             'minimum_os_version': '10.10',
             'name': 'Nextcloud',
             'unattended_install': True},
 'verbose': 3}
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '^Nextcloud-.*pkg$',
           'github_repo': 'nextcloud/desktop',
           'include_prereleases': ''}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Matched regex '^Nextcloud-.*pkg$' among asset(s): Nextcloud-3.1.0-setup.exe, Nextcloud-3.1.0-setup.exe.asc, Nextcloud-3.1.0-x64.msi, Nextcloud-3.1.0-x64.msi.asc, Nextcloud-3.1.0-x86.msi, Nextcloud-3.1.0-x86.msi.asc, Nextcloud-3.1.0-x86_64.AppImage, Nextcloud-3.1.0-x86_64.AppImage.asc, Nextcloud-3.1.0.pkg, Nextcloud-3.1.0.pkg.asc
GitHubReleasesInfoProvider: Selected asset 'Nextcloud-3.1.0.pkg' from release 'Release 3.1.0'
{'Output': {'release_notes': '* '
                             '[desktop#2221](https://github.com/nextcloud/desktop/pull/2221) '
                             'Make QML code more declarative by using '
                             'properties\r\n'
                             '* '
                             '[desktop#2497](https://github.com/nextcloud/desktop/pull/2497) '
                             'MacOS: Fix memory leak in '
                             'FolderWatcherPrivate::startWatching\r\n'
                             '* '
                             '[desktop#2500](https://github.com/nextcloud/desktop/pull/2500) '
                             'Windows MSI: Update Docs & add SKIPAUTOUPDATE '
                             'property\r\n'
                             '* '
                             '[desktop#2512](https://github.com/nextcloud/desktop/pull/2512) '
                             'Handle redirects when downloading updates\r\n'
                             '* '
                             '[desktop#2514](https://github.com/nextcloud/desktop/pull/2514) '
                             'Make it easier for user to provide debug '
                             'information\r\n'
                             '* '
                             '[desktop#2520](https://github.com/nextcloud/desktop/pull/2520) '
                             'Handle ask for optional password capability\r\n'
                             '* '
                             '[desktop#2521](https://github.com/nextcloud/desktop/pull/2521) '
                             'Use friendly user agent during authentication\r\n'
                             '* '
                             '[desktop#2527](https://github.com/nextcloud/desktop/pull/2527) '
                             'Improve conflict handling gui\r\n'
                             '* '
                             '[desktop#2530](https://github.com/nextcloud/desktop/pull/2530) '
                             'Repair the Windows build\r\n'
                             '* '
                             '[desktop#2531](https://github.com/nextcloud/desktop/pull/2531) '
                             'Bring back the "Pause sync" action in the '
                             'systray context menu\r\n'
                             '* '
                             '[desktop#2534](https://github.com/nextcloud/desktop/pull/2534) '
                             'Connection wizard improvements\r\n'
                             '* '
                             '[desktop#2540](https://github.com/nextcloud/desktop/pull/2540) '
                             'Add last / to exclude list file path.\r\n'
                             '* '
                             '[desktop#2541](https://github.com/nextcloud/desktop/pull/2541) '
                             "Don't use nullptr for QFlags\r\n"
                             '* '
                             '[desktop#2542](https://github.com/nextcloud/desktop/pull/2542) '
                             'Avoid string translation puzzle\r\n'
                             '* '
                             '[desktop#2543](https://github.com/nextcloud/desktop/pull/2543) '
                             'Update bookmarks location\r\n'
                             '* '
                             '[desktop#2551](https://github.com/nextcloud/desktop/pull/2551) '
                             'Fix share dialog animation for enforced password '
                             'policy\r\n'
                             '* '
                             '[desktop#2568](https://github.com/nextcloud/desktop/pull/2568) '
                             'Fix crash when clicking on folder with status '
                             '403 in the main dialog.\r\n'
                             '* '
                             '[desktop#2572](https://github.com/nextcloud/desktop/pull/2572) '
                             'Avoid depth infinity propfind for e2ee\r\n'
                             '* '
                             '[desktop#2575](https://github.com/nextcloud/desktop/pull/2575) '
                             'Expose branding values to qtquick\r\n'
                             '* '
                             '[desktop#2580](https://github.com/nextcloud/desktop/pull/2580) '
                             'Delay initialization of SettingsDialog\r\n'
                             '* '
                             '[desktop#2581](https://github.com/nextcloud/desktop/pull/2581) '
                             'Ensure we quickly show/hide the systray window '
                             'on startup\r\n'
                             '* '
                             '[desktop#2582](https://github.com/nextcloud/desktop/pull/2582) '
                             'Also output the event flags in the debug logs\r\n'
                             '* '
                             '[desktop#2586](https://github.com/nextcloud/desktop/pull/2586) '
                             'L10n: Add a space in generalsettings.ui\r\n'
                             '* '
                             '[desktop#2587](https://github.com/nextcloud/desktop/pull/2587) '
                             'Triple dot to ellipsis\r\n'
                             '* '
                             '[desktop#2589](https://github.com/nextcloud/desktop/pull/2589) '
                             'Misc fixes for Windows 7\r\n'
                             '* '
                             '[desktop#2591](https://github.com/nextcloud/desktop/pull/2591) '
                             'Remove last left over of the "remote" wording\r\n'
                             '* '
                             '[desktop#2603](https://github.com/nextcloud/desktop/pull/2603) '
                             'Get rid of FindQt5Keychain.cmake\r\n'
                             '* '
                             '[desktop#2615](https://github.com/nextcloud/desktop/pull/2615) '
                             'Fetch apps when we get connected only\r\n'
                             '* '
                             '[desktop#2616](https://github.com/nextcloud/desktop/pull/2616) '
                             'Move journaldb files back to sync folders\r\n'
                             '* '
                             '[desktop#2620](https://github.com/nextcloud/desktop/pull/2620) '
                             'Make sure the settings dialog exist before '
                             'hiding it\r\n'
                             '* '
                             '[desktop#2621](https://github.com/nextcloud/desktop/pull/2621) '
                             '[documentation] upload chunks config\r\n'
                             '* '
                             '[desktop#2630](https://github.com/nextcloud/desktop/pull/2630) '
                             'Master is now 3.0.81\r\n'
                             '* '
                             '[desktop#2647](https://github.com/nextcloud/desktop/pull/2647) '
                             'Cherry pick updater fixes and improvements\r\n'
                             '* '
                             '[desktop#2648](https://github.com/nextcloud/desktop/pull/2648) '
                             'Issue a warning for Debian pipeline failures but '
                             "don't fail the CI\r\n"
                             '* '
                             '[desktop#2652](https://github.com/nextcloud/desktop/pull/2652) '
                             'Handle the case when the release version differs '
                             'from that in VERSION.cmake\r\n'
                             '* '
                             '[desktop#2655](https://github.com/nextcloud/desktop/pull/2655) '
                             'Use dynamic path for account online/offline '
                             'state icon. Refresh GUI on connection state '
                             'change.\r\n'
                             '* '
                             '[desktop#2658](https://github.com/nextcloud/desktop/pull/2658) '
                             'Enable the QML debugger on debug builds\r\n'
                             '* '
                             '[desktop#2660](https://github.com/nextcloud/desktop/pull/2660) '
                             'FolderWatcher: fixes and improvements\r\n'
                             '* '
                             '[desktop#2662](https://github.com/nextcloud/desktop/pull/2662) '
                             'Fix QML debugging by removing incorrect '
                             'dependency\r\n'
                             '* '
                             '[desktop#2663](https://github.com/nextcloud/desktop/pull/2663) '
                             'Fix Windows compilation broken after QML '
                             'debugging fix.\r\n'
                             '* '
                             '[desktop#2665](https://github.com/nextcloud/desktop/pull/2665) '
                             'Sparkle build fixes\r\n'
                             '* '
                             '[desktop#2666](https://github.com/nextcloud/desktop/pull/2666) '
                             'Notification action buttons and context menu\r\n'
                             '* '
                             '[desktop#2667](https://github.com/nextcloud/desktop/pull/2667) '
                             'Master is now 3.0.82.\r\n'
                             '* '
                             '[desktop#2675](https://github.com/nextcloud/desktop/pull/2675) '
                             'Fix AppImage build\r\n'
                             '* '
                             '[desktop#2677](https://github.com/nextcloud/desktop/pull/2677) '
                             'Fix macOS bug where tray window causes spaces to '
                             'switch\r\n'
                             '* '
                             '[desktop#2682](https://github.com/nextcloud/desktop/pull/2682) '
                             'Add debug log to check which folders are being '
                             'skipped during syncing.\r\n'
                             '* '
                             '[desktop#2685](https://github.com/nextcloud/desktop/pull/2685) '
                             'Fixed slow sharee search in the share dialog\r\n'
                             '* '
                             '[desktop#2686](https://github.com/nextcloud/desktop/pull/2686) '
                             'Added sharing via email.\r\n'
                             '* '
                             '[desktop#2690](https://github.com/nextcloud/desktop/pull/2690) '
                             'Update documentation on how to generate debug '
                             'logs.\r\n'
                             '* '
                             '[desktop#2696](https://github.com/nextcloud/desktop/pull/2696) '
                             'Bump master version to 3.1.0',
            'url': 'https://github.com/nextcloud/desktop/releases/download/v3.1.0/Nextcloud-3.1.0.pkg',
            'version': '3.1.0'}}
URLDownloader
{'Input': {'filename': 'Nextcloud.pkg',
           'url': 'https://github.com/nextcloud/desktop/releases/download/v3.1.0/Nextcloud-3.1.0.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient/downloads/Nextcloud.pkg
{'Output': {'pathname': '/Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient/downloads/Nextcloud.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: Nextcloud '
                                        'GmbH (NKUJUXUJ3B)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '/Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient/downloads/Nextcloud.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Nextcloud.pkg":
CodeSignatureVerifier:    Status: signed by a certificate trusted by Mac OS X
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Nextcloud GmbH (NKUJUXUJ3B)
CodeSignatureVerifier:        SHA1 fingerprint: 1B 8B 3F D4 A0 AD CC 5B F4 38 5F A1 A5 0F 45 47 DE 73 C9 5E
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
CodeSignatureVerifier:        -----------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/mnt/munkipkgs/',
           'pkg_path': '/Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient/downloads/Nextcloud.pkg',
           'pkginfo': {'blocking_applications': ['nextcloud.app',
                                                 'QtWebEngineProcess.app'],
                       'catalogs': ['production'],
                       'category': 'Cloud',
                       'description': 'A safe home for all your data. Access, '
                                      'share and protect your files, '
                                      'calendars, contacts, mail & more from '
                                      'any device, on your terms.',
                       'developer': 'Nextcloud GmbH',
                       'display_name': 'Nextcloud (only for external data)',
                       'minimum_os_version': '10.10',
                       'name': 'Nextcloud',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/Nextcloud'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /mnt/munkipkgs/
MunkiImporter: Copied pkginfo to: /mnt/munkipkgs/pkgsinfo/apps/Nextcloud/Nextcloud-3.1.0.4209.plist
MunkiImporter:            pkg to: /mnt/munkipkgs/pkgs/apps/Nextcloud/Nextcloud-3.1.0.4209.pkg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'production',
                                                       'icon_repo_path': '',
                                                       'name': 'Nextcloud',
                                                       'pkg_repo_path': 'apps/Nextcloud/Nextcloud-3.1.0.4209.pkg',
                                                       'pkginfo_path': 'apps/Nextcloud/Nextcloud-3.1.0.4209.plist',
                                                       'version': '3.1.0.4209'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'admin',
                                         'creation_date': datetime.datetime(2020, 12, 18, 11, 37, 11),
                                         'munki_version': '5.2.1.4260',
                                         'os_version': '10.14.6'},
                           'autoremove': False,
                           'blocking_applications': ['nextcloud.app',
                                                     'QtWebEngineProcess.app'],
                           'catalogs': ['production'],
                           'category': 'Cloud',
                           'description': 'A safe home for all your data. '
                                          'Access, share and protect your '
                                          'files, calendars, contacts, mail & '
                                          'more from any device, on your '
                                          'terms.',
                           'developer': 'Nextcloud GmbH',
                           'display_name': 'Nextcloud (only for external data)',
                           'installed_size': 217681,
                           'installer_item_hash': '32df4c295328fb145ed44bd07c65da667331947a8e3eff60c22bed5b85f234ed',
                           'installer_item_location': 'apps/Nextcloud/Nextcloud-3.1.0.4209.pkg',
                           'installer_item_size': 85369,
                           'minimum_os_version': '10.10',
                           'name': 'Nextcloud',
                           'receipts': [{'installed_size': 217681,
                                         'packageid': 'com.nextcloud.desktopclient',
                                         'version': '3.1.0.4209'}],
                           'unattended_install': True,
                           'uninstall_method': 'removepackages',
                           'uninstallable': True,
                           'version': '3.1.0.4209'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/mnt/munkipkgs/pkgs/apps/Nextcloud/Nextcloud-3.1.0.4209.pkg',
            'pkginfo_repo_path': '/mnt/munkipkgs/pkgsinfo/apps/Nextcloud/Nextcloud-3.1.0.4209.plist'}}
{'AUTOPKG_VERSION': '2.2',
 'CHECK_FILESIZE_ONLY': False,
 'CURL_PATH': '/usr/bin/curl',
 'FAIL_RECIPES_WITHOUT_TRUST_INFO': True,
 'GITHUB_REPO': 'nextcloud/desktop',
 'GIT_PATH': '/Applications/Xcode.app/Contents/Developer/usr/bin/git',
 'INCLUDE_PRERELEASES': '',
 'MUNKILIB_DIR': '/usr/local/munki',
 'MUNKI_CATEGORY': 'Cloud',
 'MUNKI_REPO': '/mnt/munkipkgs/',
 'MUNKI_REPO_PLUGIN': 'FileRepo',
 'MUNKI_REPO_SUBDIR': 'apps/Nextcloud',
 'NAME': 'Nextcloud',
 'PARENT_RECIPES': ['/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes/Nextcloud/NextcloudDesktopClient.munki.recipe',
                    '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes/Nextcloud/NextcloudDesktopClient.download.recipe'],
 'RECIPE_CACHE_DIR': '/Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient',
 'RECIPE_DIR': '/Users/admin/Library/AutoPkg/RecipeOverrides',
 'RECIPE_OVERRIDE_DIRS': ['~/Library/AutoPkg/RecipeOverrides'],
 'RECIPE_PATH': '/Users/admin/Library/AutoPkg/RecipeOverrides/NextcloudDesktopClient.munki.recipe',
 'RECIPE_REPOS': {'/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.48kRAM-recipes': {'URL': 'https://github.com/autopkg/48kRAM-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.andrewvalentine-recipes': {'URL': 'https://github.com/autopkg/andrewvalentine-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.apettinen-recipes': {'URL': 'https://github.com/autopkg/apettinen-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.aysiu-recipes': {'URL': 'https://github.com/autopkg/aysiu-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.bochoven-recipes': {'URL': 'https://github.com/autopkg/bochoven-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes': {'URL': 'https://github.com/autopkg/dataJAR-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes': {'URL': 'https://github.com/autopkg/foigus-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.gerardkok-recipes': {'URL': 'https://github.com/autopkg/gerardkok-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes': {'URL': 'https://github.com/autopkg/grahamgilbert-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes': {'URL': 'https://github.com/autopkg/grahampugh-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.hansen-m-recipes': {'URL': 'https://github.com/autopkg/hansen-m-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes': {'URL': 'https://github.com/autopkg/hjuutilainen-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes': {'URL': 'https://github.com/autopkg/homebysix-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jaharmi-recipes': {'URL': 'https://github.com/autopkg/jaharmi-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes': {'URL': 'https://github.com/autopkg/jessepeterson-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes': {'URL': 'https://github.com/autopkg/jleggat-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes': {'URL': 'https://github.com/autopkg/joshua-d-miller-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jpiel-recipes': {'URL': 'https://github.com/autopkg/jpiel-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes': {'URL': 'https://github.com/autopkg/keeleysam-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes': {'URL': 'https://github.com/autopkg/killahquam-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes': {'URL': 'https://github.com/autopkg/mosen-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes': {'URL': 'https://github.com/autopkg/nmcspadden-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peshay-recipes': {'URL': 'https://github.com/autopkg/peshay-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes': {'URL': 'https://github.com/autopkg/peterkelm-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes': {'URL': 'https://github.com/autopkg/recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.robperc-recipes': {'URL': 'https://github.com/autopkg/robperc-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes': {'URL': 'https://github.com/autopkg/scriptingosx-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.timsutton-recipes': {'URL': 'https://github.com/autopkg/timsutton-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes': {'URL': 'https://github.com/autopkg/ygini-recipes.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.hjuutilainen.autopkg-virustotalanalyzer': {'URL': 'https://github.com/hjuutilainen/autopkg-virustotalanalyzer.git'},
                  '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.mpib.autopkg-recipes': {'URL': 'https://github.com/mpib/autopkg-recipes'}},
 'RECIPE_SEARCH_DIRS': ['.',
                        '~/Library/AutoPkg/Recipes',
                        '/Library/AutoPkg/Recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.hansen-m-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.joshua-d-miller-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jessepeterson-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.hjuutilainen-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.keeleysam-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.mosen-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jleggat-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.gerardkok-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.robperc-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.killahquam-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.48kRAM-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.hjuutilainen.autopkg-virustotalanalyzer',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.ygini-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peshay-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.timsutton-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jaharmi-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.bochoven-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahamgilbert-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.nmcspadden-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.scriptingosx-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.aysiu-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.grahampugh-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.andrewvalentine-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.apettinen-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.dataJAR-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.jpiel-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.mpib.autopkg-recipes',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes',
                        '',
                        '/Users/admin/Library/AutoPkg/RecipeRepos/com.github.autopkg.peterkelm-recipes/Nextcloud'],
 'VIRUSTOTAL_ALWAYS_REPORT': False,
 'asset_regex': '^Nextcloud-.*pkg$',
 'download_changed': False,
 'etag': '',
 'expected_authority_names': ['Developer ID Installer: Nextcloud GmbH '
                              '(NKUJUXUJ3B)',
                              'Developer ID Certification Authority',
                              'Apple Root CA'],
 'filename': 'Nextcloud.pkg',
 'force_munki_repo_lib': False,
 'github_repo': 'nextcloud/desktop',
 'icon_repo_path': '',
 'include_prereleases': '',
 'input_path': '/Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient/downloads/Nextcloud.pkg',
 'last_modified': '',
 'munki_importer_summary_result': {'data': {'catalogs': 'production',
                                            'icon_repo_path': '',
                                            'name': 'Nextcloud',
                                            'pkg_repo_path': 'apps/Nextcloud/Nextcloud-3.1.0.4209.pkg',
                                            'pkginfo_path': 'apps/Nextcloud/Nextcloud-3.1.0.4209.plist',
                                            'version': '3.1.0.4209'},
                                   'report_fields': ['name',
                                                     'version',
                                                     'catalogs',
                                                     'pkginfo_path',
                                                     'pkg_repo_path',
                                                     'icon_repo_path'],
                                   'summary_text': 'The following new items '
                                                   'were imported into Munki:'},
 'munki_info': {'_metadata': {'created_by': 'admin',
                              'creation_date': datetime.datetime(2020, 12, 18, 11, 37, 11),
                              'munki_version': '5.2.1.4260',
                              'os_version': '10.14.6'},
                'autoremove': False,
                'blocking_applications': ['nextcloud.app',
                                          'QtWebEngineProcess.app'],
                'catalogs': ['production'],
                'category': 'Cloud',
                'description': 'A safe home for all your data. Access, share '
                               'and protect your files, calendars, contacts, '
                               'mail & more from any device, on your terms.',
                'developer': 'Nextcloud GmbH',
                'display_name': 'Nextcloud (only for external data)',
                'installed_size': 217681,
                'installer_item_hash': '32df4c295328fb145ed44bd07c65da667331947a8e3eff60c22bed5b85f234ed',
                'installer_item_location': 'apps/Nextcloud/Nextcloud-3.1.0.4209.pkg',
                'installer_item_size': 85369,
                'minimum_os_version': '10.10',
                'name': 'Nextcloud',
                'receipts': [{'installed_size': 217681,
                              'packageid': 'com.nextcloud.desktopclient',
                              'version': '3.1.0.4209'}],
                'unattended_install': True,
                'uninstall_method': 'removepackages',
                'uninstallable': True,
                'version': '3.1.0.4209'},
 'munki_repo_changed': True,
 'pathname': '/Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient/downloads/Nextcloud.pkg',
 'pkg_path': '/mnt/munkipkgs/pkgs/apps/Nextcloud/Nextcloud-3.1.0.4209.pkg',
 'pkg_repo_path': '/mnt/munkipkgs/pkgs/apps/Nextcloud/Nextcloud-3.1.0.4209.pkg',
 'pkginfo': {'blocking_applications': ['nextcloud.app',
                                       'QtWebEngineProcess.app'],
             'catalogs': ['production'],
             'category': 'Cloud',
             'description': 'A safe home for all your data. Access, share and '
                            'protect your files, calendars, contacts, mail & '
                            'more from any device, on your terms.',
             'developer': 'Nextcloud GmbH',
             'display_name': 'Nextcloud (only for external data)',
             'minimum_os_version': '10.10',
             'name': 'Nextcloud',
             'unattended_install': True},
 'pkginfo_repo_path': '/mnt/munkipkgs/pkgsinfo/apps/Nextcloud/Nextcloud-3.1.0.4209.plist',
 'prefetch_filename': False,
 'release_notes': '* '
                  '[desktop#2221](https://github.com/nextcloud/desktop/pull/2221) '
                  'Make QML code more declarative by using properties\r\n'
                  '* '
                  '[desktop#2497](https://github.com/nextcloud/desktop/pull/2497) '
                  'MacOS: Fix memory leak in '
                  'FolderWatcherPrivate::startWatching\r\n'
                  '* '
                  '[desktop#2500](https://github.com/nextcloud/desktop/pull/2500) '
                  'Windows MSI: Update Docs & add SKIPAUTOUPDATE property\r\n'
                  '* '
                  '[desktop#2512](https://github.com/nextcloud/desktop/pull/2512) '
                  'Handle redirects when downloading updates\r\n'
                  '* '
                  '[desktop#2514](https://github.com/nextcloud/desktop/pull/2514) '
                  'Make it easier for user to provide debug information\r\n'
                  '* '
                  '[desktop#2520](https://github.com/nextcloud/desktop/pull/2520) '
                  'Handle ask for optional password capability\r\n'
                  '* '
                  '[desktop#2521](https://github.com/nextcloud/desktop/pull/2521) '
                  'Use friendly user agent during authentication\r\n'
                  '* '
                  '[desktop#2527](https://github.com/nextcloud/desktop/pull/2527) '
                  'Improve conflict handling gui\r\n'
                  '* '
                  '[desktop#2530](https://github.com/nextcloud/desktop/pull/2530) '
                  'Repair the Windows build\r\n'
                  '* '
                  '[desktop#2531](https://github.com/nextcloud/desktop/pull/2531) '
                  'Bring back the "Pause sync" action in the systray context '
                  'menu\r\n'
                  '* '
                  '[desktop#2534](https://github.com/nextcloud/desktop/pull/2534) '
                  'Connection wizard improvements\r\n'
                  '* '
                  '[desktop#2540](https://github.com/nextcloud/desktop/pull/2540) '
                  'Add last / to exclude list file path.\r\n'
                  '* '
                  '[desktop#2541](https://github.com/nextcloud/desktop/pull/2541) '
                  "Don't use nullptr for QFlags\r\n"
                  '* '
                  '[desktop#2542](https://github.com/nextcloud/desktop/pull/2542) '
                  'Avoid string translation puzzle\r\n'
                  '* '
                  '[desktop#2543](https://github.com/nextcloud/desktop/pull/2543) '
                  'Update bookmarks location\r\n'
                  '* '
                  '[desktop#2551](https://github.com/nextcloud/desktop/pull/2551) '
                  'Fix share dialog animation for enforced password policy\r\n'
                  '* '
                  '[desktop#2568](https://github.com/nextcloud/desktop/pull/2568) '
                  'Fix crash when clicking on folder with status 403 in the '
                  'main dialog.\r\n'
                  '* '
                  '[desktop#2572](https://github.com/nextcloud/desktop/pull/2572) '
                  'Avoid depth infinity propfind for e2ee\r\n'
                  '* '
                  '[desktop#2575](https://github.com/nextcloud/desktop/pull/2575) '
                  'Expose branding values to qtquick\r\n'
                  '* '
                  '[desktop#2580](https://github.com/nextcloud/desktop/pull/2580) '
                  'Delay initialization of SettingsDialog\r\n'
                  '* '
                  '[desktop#2581](https://github.com/nextcloud/desktop/pull/2581) '
                  'Ensure we quickly show/hide the systray window on '
                  'startup\r\n'
                  '* '
                  '[desktop#2582](https://github.com/nextcloud/desktop/pull/2582) '
                  'Also output the event flags in the debug logs\r\n'
                  '* '
                  '[desktop#2586](https://github.com/nextcloud/desktop/pull/2586) '
                  'L10n: Add a space in generalsettings.ui\r\n'
                  '* '
                  '[desktop#2587](https://github.com/nextcloud/desktop/pull/2587) '
                  'Triple dot to ellipsis\r\n'
                  '* '
                  '[desktop#2589](https://github.com/nextcloud/desktop/pull/2589) '
                  'Misc fixes for Windows 7\r\n'
                  '* '
                  '[desktop#2591](https://github.com/nextcloud/desktop/pull/2591) '
                  'Remove last left over of the "remote" wording\r\n'
                  '* '
                  '[desktop#2603](https://github.com/nextcloud/desktop/pull/2603) '
                  'Get rid of FindQt5Keychain.cmake\r\n'
                  '* '
                  '[desktop#2615](https://github.com/nextcloud/desktop/pull/2615) '
                  'Fetch apps when we get connected only\r\n'
                  '* '
                  '[desktop#2616](https://github.com/nextcloud/desktop/pull/2616) '
                  'Move journaldb files back to sync folders\r\n'
                  '* '
                  '[desktop#2620](https://github.com/nextcloud/desktop/pull/2620) '
                  'Make sure the settings dialog exist before hiding it\r\n'
                  '* '
                  '[desktop#2621](https://github.com/nextcloud/desktop/pull/2621) '
                  '[documentation] upload chunks config\r\n'
                  '* '
                  '[desktop#2630](https://github.com/nextcloud/desktop/pull/2630) '
                  'Master is now 3.0.81\r\n'
                  '* '
                  '[desktop#2647](https://github.com/nextcloud/desktop/pull/2647) '
                  'Cherry pick updater fixes and improvements\r\n'
                  '* '
                  '[desktop#2648](https://github.com/nextcloud/desktop/pull/2648) '
                  "Issue a warning for Debian pipeline failures but don't fail "
                  'the CI\r\n'
                  '* '
                  '[desktop#2652](https://github.com/nextcloud/desktop/pull/2652) '
                  'Handle the case when the release version differs from that '
                  'in VERSION.cmake\r\n'
                  '* '
                  '[desktop#2655](https://github.com/nextcloud/desktop/pull/2655) '
                  'Use dynamic path for account online/offline state icon. '
                  'Refresh GUI on connection state change.\r\n'
                  '* '
                  '[desktop#2658](https://github.com/nextcloud/desktop/pull/2658) '
                  'Enable the QML debugger on debug builds\r\n'
                  '* '
                  '[desktop#2660](https://github.com/nextcloud/desktop/pull/2660) '
                  'FolderWatcher: fixes and improvements\r\n'
                  '* '
                  '[desktop#2662](https://github.com/nextcloud/desktop/pull/2662) '
                  'Fix QML debugging by removing incorrect dependency\r\n'
                  '* '
                  '[desktop#2663](https://github.com/nextcloud/desktop/pull/2663) '
                  'Fix Windows compilation broken after QML debugging fix.\r\n'
                  '* '
                  '[desktop#2665](https://github.com/nextcloud/desktop/pull/2665) '
                  'Sparkle build fixes\r\n'
                  '* '
                  '[desktop#2666](https://github.com/nextcloud/desktop/pull/2666) '
                  'Notification action buttons and context menu\r\n'
                  '* '
                  '[desktop#2667](https://github.com/nextcloud/desktop/pull/2667) '
                  'Master is now 3.0.82.\r\n'
                  '* '
                  '[desktop#2675](https://github.com/nextcloud/desktop/pull/2675) '
                  'Fix AppImage build\r\n'
                  '* '
                  '[desktop#2677](https://github.com/nextcloud/desktop/pull/2677) '
                  'Fix macOS bug where tray window causes spaces to switch\r\n'
                  '* '
                  '[desktop#2682](https://github.com/nextcloud/desktop/pull/2682) '
                  'Add debug log to check which folders are being skipped '
                  'during syncing.\r\n'
                  '* '
                  '[desktop#2685](https://github.com/nextcloud/desktop/pull/2685) '
                  'Fixed slow sharee search in the share dialog\r\n'
                  '* '
                  '[desktop#2686](https://github.com/nextcloud/desktop/pull/2686) '
                  'Added sharing via email.\r\n'
                  '* '
                  '[desktop#2690](https://github.com/nextcloud/desktop/pull/2690) '
                  'Update documentation on how to generate debug logs.\r\n'
                  '* '
                  '[desktop#2696](https://github.com/nextcloud/desktop/pull/2696) '
                  'Bump master version to 3.1.0',
 'repo_subdirectory': 'apps/Nextcloud',
 'url': 'https://github.com/nextcloud/desktop/releases/download/v3.1.0/Nextcloud-3.1.0.pkg',
 'verbose': 3,
 'version': '3.1.0'}
Receipt written to /Users/admin/Library/AutoPkg/Cache/local.munki.NextcloudDesktopClient/receipts/NextcloudDesktopClient.munki-receipt-20201218-123712.plist

The following new items were imported into Munki:
    Name       Version     Catalogs    Pkginfo Path                               Pkg Repo Path                            Icon Repo Path  
    ----       -------     --------    ------------                               -------------                            --------------  
    Nextcloud  3.1.0.4209  production  apps/Nextcloud/Nextcloud-3.1.0.4209.plist  apps/Nextcloud/Nextcloud-3.1.0.4209.pkg                  
```