### PR TITLE
Update AffinityPhoto.download.recipe

### DIFF
--- a/Serif/AffinityPhoto.download.recipe
+++ b/Serif/AffinityPhoto.download.recipe
@@ -36,7 +36,7 @@
                 <key>url</key>
                 <string>%url%?Expires=%expires%&amp;Signature=%signature%&amp;Key-Pair-Id=%key%</string>
 				<key>filename</key>
-				<string>affinity-photo-%version%.dmg</string>
+				<string>%NAME%-%version%.dmg</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>


### PR DESCRIPTION
With this PR I'm suggesting to modify the name of the downloaded file (which will also become the filename of the .plist file imported by Munki) so that it reflects the `%NAME%` input variable instead of some hard-coded value.
This way I could keep the `pkgs` and `pkgsinfo` path exactly the same.