### PR TITLE
Changes to Serif (Affinity) Recipes

### DIFF
--- a/Serif/AffinityDesigner.download.recipe
+++ b/Serif/AffinityDesigner.download.recipe
@@ -12,10 +12,10 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 	<string>com.github.peterkelm.download.AffinityDesigner</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>AffinityDesigner</string>
 		<key>LANGUAGE_CODE</key>
 		<string>de</string>
+		<key>NAME</key>
+		<string>AffinityDesigner</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -37,10 +37,10 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 		<dict>
 			<key>Arguments</key>
 			<dict>
-                <key>url</key>
-                <string>%url%?Expires=%expires%&amp;Signature=%signature%&amp;Key-Pair-Id=%key%</string>
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
+				<key>url</key>
+				<string>%url%?Expires=%expires%&amp;Signature=%signature%&amp;Key-Pair-Id=%key%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -60,17 +60,6 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>
-		<!-- dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%pathname%/Affinity Designer.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict -->
 	</array>
 </dict>
 </plist>

--- a/Serif/AffinityDesigner.download.recipe
+++ b/Serif/AffinityDesigner.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)
+
+NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States English) is also valid and there may be other valid language codes as well.</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Affinity Designer.</string>
 	<key>Identifier</key>
@@ -12,6 +14,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>AffinityDesigner</string>
+		<key>LANGUAGE_CODE</key>
+		<string>de</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -25,7 +29,7 @@
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>
-				<string>https://store.serif.com/de/update/macos/designer/1/</string>
+				<string>https://store.serif.com/%LANGUAGE_CODE%/update/macos/designer/1/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Serif/AffinityDesigner.munki.recipe
+++ b/Serif/AffinityDesigner.munki.recipe
@@ -40,17 +40,6 @@
 	<string>com.github.peterkelm.download.AffinityDesigner</string>
 	<key>Process</key>
 	<array>
-        <!-- dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>/Applications/Affinity Designer.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>LSMinimumSystemVersion</string>
-			</dict>
-		</dict -->
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Serif/AffinityDesigner.munki.recipe
+++ b/Serif/AffinityDesigner.munki.recipe
@@ -53,22 +53,6 @@
 				<string>LSMinimumSystemVersion</string>
 			</dict>
 		</dict -->
-    	<dict>
-    		<key>Processor</key>
-    		<string>MunkiPkginfoMerger</string>
-    		<key>Arguments</key>
-    		<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>blocking_applications</key>
-					<array>
-						<string>Affinity Designer</string>
-					</array>
-                    <!-- key>minimum_os_version</key>
-					<string>%version%</string -->
-				</dict>	
-			</dict>
-		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Serif/AffinityDesigner.munki.recipe
+++ b/Serif/AffinityDesigner.munki.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string></string>
+		<string>apps/serif</string>
 		<key>NAME</key>
 		<string>AffinityDesigner</string>
 		<key>pkginfo</key>
@@ -30,8 +30,6 @@
 			<string>Affinity Designer</string>
 			<key>name</key>
 			<string>%NAME%</string>
-			<key>minimum_os_version</key>
-			<string>10.9</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/Serif/AffinityPhoto.download.recipe
+++ b/Serif/AffinityPhoto.download.recipe
@@ -12,10 +12,10 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 	<string>com.github.peterkelm.download.AffinityPhoto</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>AffinityPhoto</string>
 		<key>LANGUAGE_CODE</key>
 		<string>de</string>
+		<key>NAME</key>
+		<string>AffinityPhoto</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -37,10 +37,10 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 		<dict>
 			<key>Arguments</key>
 			<dict>
-                <key>url</key>
-                <string>%url%?Expires=%expires%&amp;Signature=%signature%&amp;Key-Pair-Id=%key%</string>
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
+				<key>url</key>
+				<string>%url%?Expires=%expires%&amp;Signature=%signature%&amp;Key-Pair-Id=%key%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -60,17 +60,6 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>
-		<!-- dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%pathname%/Affinity Photo.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict -->
 	</array>
 </dict>
 </plist>

--- a/Serif/AffinityPhoto.download.recipe
+++ b/Serif/AffinityPhoto.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)
+
+NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States English) is also valid and there may be other valid language codes as well.</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Affinity Photo.</string>
 	<key>Identifier</key>
@@ -12,6 +14,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>AffinityPhoto</string>
+		<key>LANGUAGE_CODE</key>
+		<string>de</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -25,7 +29,7 @@
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>
-				<string>https://store.serif.com/de/update/macos/photo/1/</string>
+				<string>https://store.serif.com/%LANGUAGE_CODE%/update/macos/photo/1/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Serif/AffinityPhoto.munki.recipe
+++ b/Serif/AffinityPhoto.munki.recipe
@@ -40,17 +40,6 @@
 	<string>com.github.peterkelm.download.AffinityPhoto</string>
 	<key>Process</key>
 	<array>
-        <!-- dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>/Applications/Affinity Photo.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>LSMinimumSystemVersion</string>
-			</dict>
-		</dict -->
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Serif/AffinityPhoto.munki.recipe
+++ b/Serif/AffinityPhoto.munki.recipe
@@ -53,22 +53,6 @@
 				<string>LSMinimumSystemVersion</string>
 			</dict>
 		</dict -->
-    	<dict>
-    		<key>Processor</key>
-    		<string>MunkiPkginfoMerger</string>
-    		<key>Arguments</key>
-    		<dict>
-				<key>additional_pkginfo</key>
-				<dict>
-					<key>blocking_applications</key>
-					<array>
-						<string>Affinity Photo</string>
-					</array>
-                    <!-- key>minimum_os_version</key>
-					<string>%version%</string -->
-				</dict>	
-			</dict>
-		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Serif/AffinityPhoto.munki.recipe
+++ b/Serif/AffinityPhoto.munki.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string></string>
+		<string>apps/serif</string>
 		<key>NAME</key>
 		<string>AffinityPhoto</string>
 		<key>pkginfo</key>
@@ -30,8 +30,6 @@
 			<string>Affinity Photo</string>
 			<key>name</key>
 			<string>%NAME%</string>
-			<key>minimum_os_version</key>
-			<string>10.9</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>

--- a/Serif/AffinityPublisher.download.recipe
+++ b/Serif/AffinityPublisher.download.recipe
@@ -3,7 +3,9 @@
 <plist version="1.0">
 <dict>
 	<key>Comment</key>
-	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot)</string>
+	<string>Created with Recipe Robot v1.1.2 (https://github.com/homebysix/recipe-robot).
+
+NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States English) is also valid and there may be other valid language codes as well.</string>
 	<key>Description</key>
 	<string>Downloads the latest version of Affinity Publisher.</string>
 	<key>Identifier</key>
@@ -12,6 +14,8 @@
 	<dict>
 		<key>NAME</key>
 		<string>AffinityPublisher</string>
+		<key>LANGUAGE_CODE</key>
+		<string>de</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -25,7 +29,7 @@
 				<key>result_output_var_name</key>
 				<string>url</string>
 				<key>url</key>
-				<string>https://store.serif.com/de/update/macos/publisher/1/</string>
+				<string>https://store.serif.com/%LANGUAGE_CODE%/update/macos/publisher/1/</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Serif/AffinityPublisher.download.recipe
+++ b/Serif/AffinityPublisher.download.recipe
@@ -12,10 +12,10 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 	<string>com.github.peterkelm.download.AffinityPublisher</string>
 	<key>Input</key>
 	<dict>
-		<key>NAME</key>
-		<string>AffinityPublisher</string>
 		<key>LANGUAGE_CODE</key>
 		<string>de</string>
+		<key>NAME</key>
+		<string>AffinityPublisher</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
@@ -37,10 +37,10 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 		<dict>
 			<key>Arguments</key>
 			<dict>
-                <key>url</key>
-                <string>%url%?Expires=%expires%&amp;Signature=%signature%&amp;Key-Pair-Id=%key%</string>
 				<key>filename</key>
 				<string>%NAME%-%version%.dmg</string>
+				<key>url</key>
+				<string>%url%?Expires=%expires%&amp;Signature=%signature%&amp;Key-Pair-Id=%key%</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLDownloader</string>
@@ -60,17 +60,6 @@ NOTE: LANGUAGE_CODE is currently set to "de" (German).  "en-us" (United States E
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>
-		<!-- dict>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>%pathname%/Affinity Publisher.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>CFBundleShortVersionString</string>
-			</dict>
-			<key>Processor</key>
-			<string>Versioner</string>
-		</dict -->
 	</array>
 </dict>
 </plist>

--- a/Serif/AffinityPublisher.munki.recipe
+++ b/Serif/AffinityPublisher.munki.recipe
@@ -40,17 +40,6 @@
 	<string>com.github.peterkelm.download.AffinityPublisher</string>
 	<key>Process</key>
 	<array>
-        <!-- dict>
-            <key>Processor</key>
-			<string>Versioner</string>
-			<key>Arguments</key>
-			<dict>
-				<key>input_plist_path</key>
-				<string>/Applications/Affinity Publisher.app/Contents/Info.plist</string>
-				<key>plist_version_key</key>
-				<string>LSMinimumSystemVersion</string>
-			</dict>
-		</dict -->
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Serif/AffinityPublisher.munki.recipe
+++ b/Serif/AffinityPublisher.munki.recipe
@@ -53,22 +53,6 @@
 				<string>LSMinimumSystemVersion</string>
 			</dict>
 		</dict -->
-    	<dict>
-    		<key>Processor</key>
-            <string>MunkiPkginfoMerger</string>
-            <key>Arguments</key>
-            <dict>
-                <key>additional_pkginfo</key>
-                <dict>
-					<key>blocking_applications</key>
-					<array>
-						<string>Affinity Publisher</string>
-					</array>
-                    <!-- key>minimum_os_version</key>
-					<string>%version%</string -->
-                </dict>
-            </dict>
-        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Serif/AffinityPublisher.munki.recipe
+++ b/Serif/AffinityPublisher.munki.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MUNKI_REPO_SUBDIR</key>
-		<string></string>
+		<string>apps/serif</string>
 		<key>NAME</key>
 		<string>AffinityPublisher</string>
 		<key>pkginfo</key>
@@ -30,8 +30,6 @@
 			<string>Affinity Publisher</string>
 			<key>name</key>
 			<string>%NAME%</string>
-			<key>minimum_os_version</key>
-			<string>10.9</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
The following changes are included:
- Support for alternate language codes (beyond German) to download the applications
- Removal of blocking_applications and minimum_os_version since both are not needed
- Adding a default MUNKI_REPO_SUBDIR rather than an empty string
- Syntactical cleanup with "plutil -convert xml1 the.recipe"