### PR TITLE
Update NextcloudDesktopClient.download.recipe

### DIFF
--- a/Nextcloud/NextcloudDesktopClient.download.recipe
+++ b/Nextcloud/NextcloudDesktopClient.download.recipe
@@ -9,7 +9,7 @@
 	<key>Input</key>
 	<dict>
 		<key>GITHUB_REPO</key>
-		<string>nextcloud/desktop</string>
+		<string>nextcloud-releases/desktop</string>
 		<key>NAME</key>
 		<string>Nextcloud</string>
 		<key>INCLUDE_PRERELEASES</key>


### PR DESCRIPTION
the binary releases are now at https://github.com/nextcloud-releases/desktop/releases instead of https://github.com/nextcloud/desktop/releases