### PR TITLE
update Nextcloud minimum version

### DIFF
--- a/Nextcloud/NextcloudDesktopClient.munki.recipe
+++ b/Nextcloud/NextcloudDesktopClient.munki.recipe
@@ -34,7 +34,7 @@
 			<key>name</key>
 			<string>%NAME%</string>
 			<key>minimum_os_version</key>
-			<string>10.10</string>
+			<string>12.0</string>
 			<key>unattended_install</key>
 			<true/>
 		</dict>


### PR DESCRIPTION
The latest Nextcloud Desktop app requires mac OS 12 or above, see <https://nextcloud.com/install/#install-clients>